### PR TITLE
Handler: CORE API search

### DIFF
--- a/softwareindex/handlers/coreapi.py
+++ b/softwareindex/handlers/coreapi.py
@@ -1,0 +1,24 @@
+import requests, json, urllib
+
+SEARCH_URL = 'http://core.ac.uk:80/api-v2/articles/search/'
+API_KEY = 'FILL THIS IN'
+
+def getCOREMentions(identifier, **kwargs):
+    """Return the number of mentions in CORE and a descriptor, as a tuple.
+    
+    Needs an API key, which can be obtained here: http://core.ac.uk/api-keys/register"""
+    params = {
+        'apiKey': API_KEY,
+        'metadata': 'false',
+        'pageSize': 100,
+        'page': 1
+    }
+    params.update(kwargs)
+
+    response = requests.get(SEARCH_URL + urllib.quote_plus(identifier), params=params)
+    response.raise_for_status()
+
+    results = response.json()
+
+    return (len(results['data'] or []),
+            'mentions in Open Access articles (via http://core.ac.uk/)')

--- a/softwareindex/handlers/coreapi.py
+++ b/softwareindex/handlers/coreapi.py
@@ -1,6 +1,6 @@
 import requests, json, urllib
 
-SEARCH_URL = 'http://core.ac.uk:80/api-v2/articles/search/'
+SEARCH_URL = 'http://core.kmi.open.ac.uk/api/search/'
 API_KEY = 'FILL THIS IN'
 
 def getCOREMentions(identifier, **kwargs):
@@ -8,10 +8,8 @@ def getCOREMentions(identifier, **kwargs):
     
     Needs an API key, which can be obtained here: http://core.ac.uk/api-keys/register"""
     params = {
-        'apiKey': API_KEY,
-        'metadata': 'false',
-        'pageSize': 100,
-        'page': 1
+        'api_key': API_KEY,
+        'format': 'json',
     }
     params.update(kwargs)
 
@@ -19,6 +17,6 @@ def getCOREMentions(identifier, **kwargs):
     response.raise_for_status()
 
     results = response.json()
+    score = results['ListRecords'][0]['total_hits']
 
-    return (len(results['data'] or []),
-            'mentions in Open Access articles (via http://core.ac.uk/)')
+    return score, 'mentions in Open Access articles (via http://core.ac.uk/)'

--- a/softwareindex/handlers/coreapi.py
+++ b/softwareindex/handlers/coreapi.py
@@ -1,22 +1,40 @@
+# This is a software index handler that gives a score based on the
+# number of mentions in open access articles.  It uses the CORE
+# aggregator (http://core.ac.uk/) to search the full text of indexed
+# articles.
+# 
+# Inputs:
+# - identifier (String)
+# 
+# Outputs:
+# - score (Number)
+# - description (String)
+
 import requests, json, urllib
 
 SEARCH_URL = 'http://core.kmi.open.ac.uk/api/search/'
 API_KEY = 'FILL THIS IN'
 
-def getCOREMentions(identifier, **kwargs):
-    """Return the number of mentions in CORE and a descriptor, as a tuple.
-    
-    Needs an API key, which can be obtained here: http://core.ac.uk/api-keys/register"""
-    params = {
-        'api_key': API_KEY,
-        'format': 'json',
-    }
-    params.update(kwargs)
+class core_handler:
 
-    response = requests.get(SEARCH_URL + urllib.quote_plus(identifier), params=params)
-    response.raise_for_status()
+    def get_score(self, identifier, **kwargs):
+        """Return the number of mentions in CORE and a descriptor, as a tuple.
 
-    results = response.json()
-    score = results['ListRecords'][0]['total_hits']
+        Needs an API key, which can be obtained here: http://core.ac.uk/api-keys/register"""
 
-    return score, 'mentions in Open Access articles (via http://core.ac.uk/)'
+        params = {
+            'api_key': API_KEY,
+            'format': 'json',
+        }
+        params.update(kwargs)
+
+        response = requests.get(SEARCH_URL + urllib.quote_plus(identifier), params=params)
+        response.raise_for_status()
+
+        results = response.json()
+        score = results['ListRecords'][0]['total_hits']
+
+        return score 
+
+    def get_description(self):
+        return 'mentions in Open Access articles (via http://core.ac.uk/)'


### PR DESCRIPTION
This is a software index handler that gives a score based on the number of mentions in open access articles.  It uses the CORE aggregator (http://core.ac.uk/) to search the full text of indexed articles.

Requires:
1. The [requests`](http://docs.python-requests.org/en/latest/index.html) python module
2. A [CORE API key](http://core.ac.uk/api-keys/register)

Doesn't do a lot of error handling right now: it just throws a `HTTPError` if any response other than `200` is received.
