### PR TITLE
Switch to CORE v2 API, now it returns totalHits.

### DIFF
--- a/softwareindex/handlers/coreapi_handler.py
+++ b/softwareindex/handlers/coreapi_handler.py
@@ -12,7 +12,7 @@
 
 import requests, urllib
 
-SEARCH_URL = 'http://core.kmi.open.ac.uk/api/search/'
+SEARCH_URL = 'http://core.ac.uk:80/api-v2/search/'
 
 class coreapi_handler:
 
@@ -22,8 +22,7 @@ class coreapi_handler:
         Needs an API key, which can be obtained here: http://core.ac.uk/api-keys/register"""
         if isinstance(software_identifier, basestring):
             params = {
-                'api_key': key,
-                'format': 'json',
+                'apiKey': key,
             }
             params.update(kwargs)
 
@@ -31,7 +30,7 @@ class coreapi_handler:
             response.raise_for_status()
 
             results = response.json()
-            score = results['ListRecords'][0]['total_hits']
+            score = results['totalHits']
 
             return score
         else:


### PR DESCRIPTION
The nice people at CORE fixe the v2 API over the weekend so that every search result also returns a `totalHits` attribute. I've switched to this as the v1 API is now deprecated.
